### PR TITLE
Upgrade Decap cms to v3.0

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
     <script>
       CMS.registerPreviewStyle(
         "https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400&display=swap"


### PR DESCRIPTION
Upgrade fixes previously encountered bug where adding a link via the rich text editor was not working in the CMS unless manually adding it in markdown edit mode.